### PR TITLE
Add PHP7 support

### DIFF
--- a/lib/errors/applicationError.php
+++ b/lib/errors/applicationError.php
@@ -1,6 +1,6 @@
 <?php 
 
-class error{
+class applicationError{
     
     public $code;
     public $message;

--- a/lib/errors/errorHandler.php
+++ b/lib/errors/errorHandler.php
@@ -15,7 +15,7 @@ class errorHandler{
 
         if(isset($error_codes[$error_code])){
             
-            $error = new error($error_codes[$error_code]);
+            $error = new applicationError($error_codes[$error_code]);
             
             return $error; 
 


### PR DESCRIPTION
The class error happens to conflict with an error class on PHP 7.x and this causes the entire system to not work on the most recent Ubuntu LTS (16.04) and likely other recent Distros. 

This simple rename fix will migrate this issue and allow for use on PHP 7.x installs.
