### PR TITLE
Correct reference to applicationError.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,7 +6,7 @@ $debug = false;
 
 // include everything in the main file so the sub-classes can access it.
 include_once __DIR__.'/lib/errors/errorHandler.php';
-include_once __DIR__.'/lib/errors/error.php';
+include_once __DIR__.'/lib/errors/applicationError.php';
 include_once __DIR__.'/lib/errors/sanityChecker.php';
 
 include_once __DIR__.'/lib/users/userHandler.php';


### PR DESCRIPTION
MatthewM never fixed the reference in index.php when he moved error.php to applicationError.php -- this solves that.
