### PR TITLE
Remove "admin panel" in sidebar unless logged in

### DIFF
--- a/lib/templates/display/info_panel.php
+++ b/lib/templates/display/info_panel.php
@@ -23,8 +23,9 @@ $loggedin = $_SESSION['loggedin'];
     </li>
 -->
     <?php }?>
-    
+    <?php if($loggedin){ ?>
     <li><a class="icon icon-params" href="<?php echo $GLOBALS['home'] . 'admin/';?>" target="_blank">admin panel</a></li>
+    <?php }?>
     <li><a></a></li>
     <?php if($loggedin or $show_uploader){ ?>
     <li><a class="icon icon-user"><?php echo $uploader; ?></a></li>


### PR DESCRIPTION
Remove the "admin panel" entry in the sidebar unless logged into the admin panel already -- no reason to expose it to users who don't know about it (or don't care.) This could be changed to an option entirely in the future...
